### PR TITLE
:sparkles: return optimal text and line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ plot_kwargs: (dict), default None
     kwargs for the plt.text() call.
     If transform is used, it only needs to be provided here, i.e. not also in plot_kwargs.
 ```
+
+The allocate call returns a tuple containing the resulting positions used to plot the text labels and the connecting label lines
+
 # Implementation and speed
 
 The implementation aims to plot as many text-boxes as possible in the free space in the plot. There are three main steps of the algorithm:


### PR DESCRIPTION
It's sometimes useful to be able to store the optimal text boxes positions.
For instance, I use it to pre-compute optimal label positions once and then reuse-cache to draw at the same positions with different colors (via a GUI and a color-picker)

It won't break previous usage since nothing was returned.

