### PR TITLE
feat: Avoid crossing label lines + Prioritize longests texts

### DIFF
--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -68,6 +68,7 @@ def allocate(
     seed: int = 0,
     direction: str = None,
     avoid_label_lines_overlap: bool = False,
+    avoid_crossing_label_lines: bool = False,
     plot_kwargs: Dict[str, Any] = None,
     **kwargs,
 ) -> Tuple[
@@ -107,6 +108,7 @@ def allocate(
         seed (int, optional): seeds order of text allocations. Defaults to 0.
         direction (str, optional): set preferred location of the boxes (south, north, east, west, northeast, northwest, southeast, southwest). Defaults to None.
         avoid_label_lines_overlap (bool, optional): If True, avoids overlap with lines drawn between text labels and locations. Defaults to False.
+        avoid_crossing_label_lines (bool, optional): If True, avoids crossing label lines. Defaults to False.
         plot_kwargs (dict, optional): kwargs for the plt.plot of the lines if draw_lines is True.
         **kwargs (): kwargs for the plt.text() call.
 
@@ -311,6 +313,7 @@ def allocate(
         direction,
         draw_lines,
         avoid_label_lines_overlap,
+        avoid_crossing_label_lines,
     )
 
     # Plot once again

--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -28,7 +28,7 @@ from textalloc.non_overlapping_boxes import (
 import numpy as np
 from mpl_toolkits.mplot3d import proj3d
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
 try:
@@ -65,9 +65,8 @@ def allocate(
     nbr_candidates: int = 200,
     linewidth: float = 1,
     textcolor: Union[str, List[str]] = "k",
-    seed: int = 0,
-    prioritize_longest_texts: bool = False,
     direction: str = None,
+    priority_strategy: Union[int, str, Callable[[float, float], float]] = None,
     avoid_label_lines_overlap: bool = False,
     avoid_crossing_label_lines: bool = False,
     plot_kwargs: Dict[str, Any] = None,
@@ -106,9 +105,9 @@ def allocate(
         nbr_candidates (int, optional): Sets the number of candidates used. Defaults to 200.
         linewidth (float, optional): width of line. Defaults to 1.
         textcolor (Union[str, List[str]], optional): color code of the text. Defaults to "k".
-        seed (int, optional): seeds order of text allocations. Defaults to 0.
-        prioritize_longest_texts (bool, optional): If True, allocates the longest texts first. Defaults to False.
         direction (str, optional): set preferred location of the boxes (south, north, east, west, northeast, northwest, southeast, southwest). Defaults to None.
+        priority_strategy (Union[int, str, Callable[[float, float], float]], optional): Set priority strategy for greedy text allocation
+            (None / random seed / strategy name among ["largest"] / priority score of a box (width, height), the larger the better). Defaults to None, which keeps the order of the text_list.
         avoid_label_lines_overlap (bool, optional): If True, avoids overlap with lines drawn between text labels and locations. Defaults to False.
         avoid_crossing_label_lines (bool, optional): If True, avoids crossing label lines. Defaults to False.
         plot_kwargs (dict, optional): kwargs for the plt.plot of the lines if draw_lines is True.
@@ -230,22 +229,6 @@ def allocate(
         "northwest",
     ]
 
-    # Seed
-    if seed > 0:
-        randinds = np.arange(x.shape[0])
-        np.random.seed(seed)
-        np.random.shuffle(randinds)
-        text_list = [text_list[i] for i in randinds]
-        x = x[randinds]
-        y = y[randinds]
-        if z is not None:
-            z = z[randinds]
-        if text_scatter_sizes is not None:
-            text_scatter_sizes = text_scatter_sizes[randinds]
-        textsize = [textsize[i] for i in randinds]
-        textcolor = [textcolor[i] for i in randinds]
-        linecolor = [linecolor[i] for i in randinds]
-
     # Create boxes in original plot
     if verbose:
         print("Creating boxes")
@@ -316,7 +299,7 @@ def allocate(
         draw_lines,
         avoid_label_lines_overlap,
         avoid_crossing_label_lines,
-        prioritize_longest_texts
+        priority_strategy
     )
 
     # Plot once again

--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -71,8 +71,8 @@ def allocate(
     plot_kwargs: Dict[str, Any] = None,
     **kwargs,
 ) -> Tuple[
-    List[Tuple[float, float]],
-    List[Tuple[Tuple[float, float], Tuple[float, float]]],
+    List[Tuple[float, float, float]],
+    List[Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]],
     List[object],
     List[object],
 ]:
@@ -111,8 +111,8 @@ def allocate(
         **kwargs (): kwargs for the plt.text() call.
 
     Returns:
-        result_text_xy (List[Tuple[float, float]]): List of resulting (x,y) positions for text labels used in the plt.text call.
-        result_lines (List[Tuple[float, float], Tuple[float, float]]): List of resulting (x,y) pairs used in the plt.plot call for drawing lines.
+        result_text_xy (List[Tuple[float, float, float]]): List of resulting (x,y, z) positions for text labels used in the plt.text call.
+        result_lines (List[Tuple[float, float, float], Tuple[float, float, float]]): List of resulting (x,y, z) pairs used in the plt.plot call for drawing lines.
         text_objects (List[plt.Text]): List of plt.Text objects from the plt.text calls.
         line_objects (List[plt.Line2D]): List of plt.Line2D objects from the plt.plot calls.
     """

--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -343,7 +343,9 @@ def allocate(
     line_objects = []
     if draw_lines:
         for line in result_lines:
-            if line is not None:
+            if line is None:
+                line_objects.append(None)
+            else:
                 x_, y_, z_ = line
                 if z_ is not None:
                     line_objects.append(
@@ -414,7 +416,9 @@ def allocate(
     # Draw texts
     text_objects = []
     for ind, xyz in enumerate(result_text_xyz):
-        if xyz is not None:
+        if xyz is None:
+            text_objects.append(None)
+        else:
             if z is not None:
                 text_objects.append(
                     ax.text(

--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -66,6 +66,7 @@ def allocate(
     linewidth: float = 1,
     textcolor: Union[str, List[str]] = "k",
     seed: int = 0,
+    prioritize_longest_texts: bool = False,
     direction: str = None,
     avoid_label_lines_overlap: bool = False,
     avoid_crossing_label_lines: bool = False,
@@ -106,6 +107,7 @@ def allocate(
         linewidth (float, optional): width of line. Defaults to 1.
         textcolor (Union[str, List[str]], optional): color code of the text. Defaults to "k".
         seed (int, optional): seeds order of text allocations. Defaults to 0.
+        prioritize_longest_texts (bool, optional): If True, allocates the longest texts first. Defaults to False.
         direction (str, optional): set preferred location of the boxes (south, north, east, west, northeast, northwest, southeast, southwest). Defaults to None.
         avoid_label_lines_overlap (bool, optional): If True, avoids overlap with lines drawn between text labels and locations. Defaults to False.
         avoid_crossing_label_lines (bool, optional): If True, avoids crossing label lines. Defaults to False.
@@ -314,6 +316,7 @@ def allocate(
         draw_lines,
         avoid_label_lines_overlap,
         avoid_crossing_label_lines,
+        prioritize_longest_texts
     )
 
     # Plot once again

--- a/src/textalloc/non_overlapping_boxes.py
+++ b/src/textalloc/non_overlapping_boxes.py
@@ -59,6 +59,7 @@ def get_non_overlapping_boxes(
     draw_lines: bool,
     avoid_label_lines_overlap: bool,
     avoid_crossing_label_lines: bool,
+    prioritize_longest_texts: bool,
 ) -> Tuple[List[Tuple[float, float, float, float, str, int]], List[int]]:
     """Finds boxes that do not have an overlap with any other objects.
 
@@ -82,6 +83,7 @@ def get_non_overlapping_boxes(
         draw_lines (bool): draws lines from original points to textboxes.
         avoid_label_lines_overlap (bool): If True, avoids overlap with lines drawn between text labels and locations.
         avoid_crossing_label_lines (bool): If True, avoids crossing label lines.
+        prioritize_longest_texts (bool): If True, allocates longest texts first.
 
     Returns:
         Tuple[List[Tuple[float, float, float, float, str, int]], List[int]]: data of non-overlapping boxes and indices of overlapping boxes.
@@ -99,18 +101,23 @@ def get_non_overlapping_boxes(
     ymaxdistance = ydiff * max_distance * aspect_ratio
 
     box_arr = np.zeros((0, 4))
-    non_overlapping_boxes = []
     has_text_scatter_sizes = text_scatter_sizes is not None
     if has_text_scatter_sizes:
         assert len(text_scatter_sizes) == len(original_boxes)
     if scatter_sizes is not None and scatter_xy is not None:
         assert len(scatter_sizes) == scatter_xy.shape[0]
 
+    if prioritize_longest_texts:
+        argsort_priority = np.argsort([-max(w, h) for (_, _, w, h, _) in original_boxes])
+    else:
+        argsort_priority = list(range(len(original_boxes)))
+
     # Iterate original boxes and find ones that do not overlap by creating multiple candidates
     non_overlapping_boxes = []
     overlapping_boxes_inds = []
-    for i, box in tqdm(enumerate(original_boxes), disable=not verbose):
-        x_original, y_original, w, h, s = box
+    previous_lines_xyxy = None
+    for i in tqdm(argsort_priority, disable=not verbose):
+        x_original, y_original, w, h, s = original_boxes[i]
         text_scatter_size = 0
         if has_text_scatter_sizes:
             text_scatter_size = text_scatter_sizes[i]


### PR DESCRIPTION
- Set correct type hint for ta.allocate (using Optional would be better, but at least i set the correct tuple size :wink:)
- Avoid label lines to cross
- Change text allocation order by starting with largest text boxes


Before
![image (29)](https://github.com/user-attachments/assets/2a7e0c50-7961-4637-ac63-21774fd9b721)
After
![image (30)](https://github.com/user-attachments/assets/1616e165-b217-423a-b137-efd79953098b)
