### PR TITLE
:sparkles: correctly handle va

### DIFF
--- a/src/textalloc/__init__.py
+++ b/src/textalloc/__init__.py
@@ -377,6 +377,12 @@ def allocate(
                 x_coord += w / 2
             elif kwargs.get("ha") == "right":
                 x_coord += w
+        if kwargs.get("va", None) is not None:
+            if kwargs.get("va") == "center":
+                y_coord += h / 2
+            elif kwargs.get("va") == "top":
+                y_coord += h
+
         if z is not None:
             x_coord, y_coord, z_coord = display_to_data(
                 [x_coord],


### PR DESCRIPTION
Correctly handle use of va="center"
(like it was done for ha)

Before
![image (59)](https://github.com/user-attachments/assets/eec864ab-c0c8-43d0-85cc-4a30a612f884)
After
![image (58)](https://github.com/user-attachments/assets/fa12cf36-e779-4079-b8fd-8af6d05fa5c9)
